### PR TITLE
Ease manual installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp -r maximus-two@wilfinitlike.gmail.com/ ~/.local/share/gnome-shell/extensions/


### PR DESCRIPTION
allow to copy straight to ~/.local/share/gnome-shell/extensions

Don't know much about gnome-shell extensions, but takes me a while to realize that directory name must contain @ 

why directory is not named with @ directly?
